### PR TITLE
Add conversion to int using to_i

### DIFF
--- a/lib/renum/enumerated_value.rb
+++ b/lib/renum/enumerated_value.rb
@@ -40,6 +40,8 @@ module Renum
 
     attr_reader :name, :index
 
+    alias to_i index
+
     # You should never directly new-up an EnumeratedValue, so this is basically internal.
     # It sets up the value with its class, so if you override, be sure to call super!
     # Better yet define init as shown in the README.

--- a/spec/renum_spec.rb
+++ b/spec/renum_spec.rb
@@ -30,6 +30,11 @@ describe "basic enum" do
     Color::GREEN.index.should == 1
   end
 
+  it "provides an integer conversion based on the index" do
+    Status::IN_PROGRESS.to_i.should == 1
+    Color::GREEN.to_i.should == 1
+  end
+
   it "provides name lookup on values" do
     Status.with_name('IN_PROGRESS').should == Status::IN_PROGRESS
     Color.with_name('GREEN').should == Color::GREEN


### PR DESCRIPTION
Adding a standard `to_i` conversion method that returns the index.