### PR TITLE
Minor Modernizations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,7 @@
 source 'https://rubygems.org'
 
 gemspec
+
+gem "rake", "~> 13.0"
+gem "rspec", "~> 3.12"
+gem "simplecov", "~> 0.22"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,38 +6,37 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    diff-lcs (1.3)
-    docile (1.3.2)
-    json (2.3.1)
-    rake (13.0.1)
-    rspec (3.8.0)
-      rspec-core (~> 3.8.0)
-      rspec-expectations (~> 3.8.0)
-      rspec-mocks (~> 3.8.0)
-    rspec-core (3.8.2)
-      rspec-support (~> 3.8.0)
-    rspec-expectations (3.8.4)
+    diff-lcs (1.5.0)
+    docile (1.4.0)
+    rake (13.0.6)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.2)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.3)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.8.0)
-    rspec-mocks (3.8.1)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.5)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.8.0)
-    rspec-support (3.8.2)
-    simplecov (0.17.0)
+      rspec-support (~> 3.12.0)
+    rspec-support (3.12.0)
+    simplecov (0.22.0)
       docile (~> 1.1)
-      json (>= 1.8, < 3)
-      simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.2)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
 
 PLATFORMS
-  ruby
+  arm64-darwin-22
 
 DEPENDENCIES
-  bundler (~> 1.17)
   rake (~> 13.0)
   renum!
-  rspec (~> 3.0)
-  simplecov (~> 0.17)
+  rspec (~> 3.12)
+  simplecov (~> 0.22)
 
 BUNDLED WITH
-   1.17.2
+   2.4.10

--- a/renum.gemspec
+++ b/renum.gemspec
@@ -21,10 +21,5 @@ Gem::Specification.new do |spec|
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
   spec.require_paths = ["lib"]
-
-  spec.add_development_dependency "bundler", "~> 1.17"
-  spec.add_development_dependency "rake", "~> 13.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "simplecov", "~> 0.17"
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,4 @@
 require 'simplecov'
 SimpleCov.start
 
-require 'rspec'
 require 'renum'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,12 @@
+RSpec.configure do |config|
+  config.expect_with :rspec do |c|
+    # Should syntax is deprecated
+    # See: https://github.com/rspec/rspec-expectations/blob/master/Should.md
+    # TODO: Upgrade should to expect syntax
+    c.syntax = [:should, :expect]  # default, enables both `should` and `expect`
+  end
+end
+
 require 'simplecov'
 SimpleCov.start
 


### PR DESCRIPTION
- remove dependency on `bundler`
- move other dev deps to `Gemfile`, as current best-practice
- updated minor versions of dev deps
- don't load `rspec` inside `spec_helper.rb`, as it will always already be loaded by then
- configure RSpec to allow deprecated `should` syntax